### PR TITLE
a7lte: Add vendorsetup with patch setup

### DIFF
--- a/patches/apply/install-common.sh
+++ b/patches/apply/install-common.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+MYABSPATH=$(readlink -f "$0")
+PATCHBASE=$(dirname "$MYABSPATH")/../common
+CMBASE=$(readlink -f "$PATCHBASE/../../../../../")
+
+for i in $(find "$PATCHBASE"/* -type d); do
+        PATCHNAME=$(basename "$i")
+        PATCHTARGET=$PATCHNAME
+        for i in $(seq 4); do
+                PATCHTARGET=$(echo $PATCHTARGET | sed 's/_/\//')
+                if [ -d "$CMBASE/$PATCHTARGET" ]; then break; fi
+        done
+        echo applying $PATCHNAME to $PATCHTARGET
+        cd "$CMBASE/$PATCHTARGET" || exit 1
+        git am -3 "$PATCHBASE/$PATCHNAME"/* || exit 1
+done
+

--- a/patches/common/frameworks_base/samsung_capacitive_backlight.patch
+++ b/patches/common/frameworks_base/samsung_capacitive_backlight.patch
@@ -1,0 +1,61 @@
+From ba2a24a46dc048e12fb3dcdec98f1d9eb4a01af6 Mon Sep 17 00:00:00 2001
+From: Pawit Pornkitprasan <p.pawit@gmail.com>
+Date: Tue, 22 Mar 2016 01:21:48 -0400
+Subject: [PATCH] Services: PowerManagerService: only turn on button light when
+ any  button is pressed
+
+* Also reduce the timeout to 2 seconds
+
+This more closely emulates stock Samsung behavior
+
+Change-Id: Ib98288dac8bfe9a8fb630f99fa74d13392c97e4f
+Signed-off-by: Jackeagle <jackeagle102@gmail.com>
+---
+ .../java/com/android/server/power/PowerManagerService.java     | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/services/core/java/com/android/server/power/PowerManagerService.java b/services/core/java/com/android/server/power/PowerManagerService.java
+index 1fd1fbd..e6a80cd 100644
+--- a/services/core/java/com/android/server/power/PowerManagerService.java
++++ b/services/core/java/com/android/server/power/PowerManagerService.java
+@@ -172,7 +172,7 @@ public final class PowerManagerService extends SystemService
+     // Default setting for double tap to wake.
+     private static final int DEFAULT_DOUBLE_TAP_TO_WAKE = 0;
+ 
+-    private static final int BUTTON_ON_DURATION = 5 * 1000;
++    private static final int BUTTON_ON_DURATION = 2 * 1000;
+ 
+     private static final float PROXIMITY_NEAR_THRESHOLD = 5.0f;
+ 
+@@ -244,6 +244,7 @@ public final class PowerManagerService extends SystemService
+     // Timestamp of the last call to user activity.
+     private long mLastUserActivityTime;
+     private long mLastUserActivityTimeNoChangeLights;
++    private long mLastButtonActivityTime;
+ 
+     // Timestamp of last interactive power hint.
+     private long mLastInteractivePowerHintTime;
+@@ -1183,6 +1184,11 @@ public final class PowerManagerService extends SystemService
+                     return true;
+                 }
+             } else {
++                if (eventTime > mLastButtonActivityTime && (event & PowerManager.USER_ACTIVITY_EVENT_BUTTON) != 0) {
++                    mLastButtonActivityTime = eventTime;
++                    mDirty |= DIRTY_USER_ACTIVITY;
++                }
++
+                 if (eventTime > mLastUserActivityTime) {
+                     mLastUserActivityTime = eventTime;
+                     mDirty |= DIRTY_USER_ACTIVITY;
+@@ -1716,7 +1722,7 @@ public final class PowerManagerService extends SystemService
+                             mKeyboardLight.setBrightness(mKeyboardVisible ?
+                                     keyboardBrightness : 0);
+                             if (mButtonTimeout != 0
+-                                    && now > mLastUserActivityTime + mButtonTimeout) {
++                                    && now > mLastButtonActivityTime + mButtonTimeout) {
+                                 mButtonsLight.setBrightness(0);
+                             } else {
+                                 if (!mProximityPositive) {
+-- 
+2.5.0
+

--- a/vendorsetup.sh
+++ b/vendorsetup.sh
@@ -1,0 +1,5 @@
+add_lunch_combo cm_a7lte-userdebug
+add_lunch_combo cm_a7lte-eng
+
+# Run device patches on the tree
+sh device/samsung/a7lte/patches/apply/install-common.sh


### PR DESCRIPTION
- Add Capacitive Backlight patch which only turn on button light when
  any  button is pressed.
- Add patch system such that it is applied on build initialization

Change-Id: Ie31f5090854c5a818f646f32a9adef2bcd79f3b4
Signed-off-by: Jackeagle jackeagle102@gmail.com
